### PR TITLE
fixed w3 css link

### DIFF
--- a/commands/help/topics/css.txt
+++ b/commands/help/topics/css.txt
@@ -2,6 +2,6 @@ See these links for learning CSS:
 
 https://www.codecademy.com/learn/web
 
-http://www.w3schools.com/w3css/
+http://www.w3schools.com/css/default.asp
 
 http://learnlayout.com/


### PR DESCRIPTION
I didn't mean to link the w3 framework. Fixed it to be the w3 tutorials.