### PR TITLE
Scan xkcd search results for first xkcd result

### DIFF
--- a/commands/xkcd/xkcd.js
+++ b/commands/xkcd/xkcd.js
@@ -27,10 +27,12 @@ module.exports = {
       request(options, (err, res, bod) => {
         const xkcdBody = cheerio.load(bod);
         try {
-          const href = xkcdBody('.result__a').first().attr('href');
-          if (href.includes('https://xkcd.com/') || href.includes('https://www.xkcd.com/')) {
-            xkcdLink = href;
-          }
+          const hrefs = xkcdBody('.result__a').each((i, link) => {
+            let href = link.attribs.href;
+            if ((href.includes('https://xkcd.com/') || href.includes('https://www.xkcd.com/')) && xkcdLink === false) {
+              xkcdLink = href;
+            }
+          });
         } catch (e) {
           message.channel.sendMessage('There was a problem with DuckDuckGo query.');
         }


### PR DESCRIPTION
This allows the bot to scan for the first xkcd result instead of saying that one does not exist if it encounters an ad on the page.