### PR TITLE
Isolate APIs tokens/keys

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -7,5 +7,6 @@ rules:
   no-constant-condition: [error, {checkLoops: false}]
   no-unused-vars: [error, {argsIgnorePattern: '^(err$|_)'}]
   no-param-reassign: [error, {props: false}]
+  import/no-unresolved: [error, {ignore: ['tokens.json']}]
 extends: airbnb
 installedESLint: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 .vscode
 
 *.DS_Store
+
+# ignore tokens file
+/tokens.json

--- a/TheAwesomeBot.js
+++ b/TheAwesomeBot.js
@@ -1,12 +1,14 @@
 const path = require('path');
 const Discord = require('discord.js');
 const Settings = require('./settings.json');
+const Tokens = require('./tokens.json');
 
 class TheAwesomeBot {
   constructor(token, discordOpt) {
     this.token = token;
     this.client = new Discord.Client(discordOpt || { autoReconnect: true });
     this.settings = Settings;
+    this.settings.tokens = Tokens; // insert tokens into our settings obj
     this.commands = {};
     this.usageList = '';
 

--- a/commands/weather/weather.js
+++ b/commands/weather/weather.js
@@ -21,7 +21,7 @@ module.exports = {
 
     // get geocode info
     let requestURL = geocodeEndpoint
-                            .replace('gkey', weatherConfig.geocode_api_key)
+                            .replace('gkey', weatherConfig.geocode_api_key || bot.settings.tokens.google_geocode)
                             .replace('input', cmdArgs);
     // do percentage encoding
     requestURL = encodeURI(requestURL);
@@ -43,7 +43,7 @@ module.exports = {
       const coordinate = geocodeData.results[0].geometry.location;
       // get weather data
       requestURL = darkskyEndpoint
-                          .replace('key', weatherConfig.darksky_api_key)
+                          .replace('key', weatherConfig.darksky_api_key || bot.settings.tokens.darksky)
                           .replace('lat', coordinate.lat)
                           .replace('lng', coordinate.lng);
 

--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,5 @@
 {
   "bot_cmd": "!bot",
-  "api_token": "",
   "voting": {
     "immuneRoles": ["Admins", "Mods"],
     "voteThreshold": 5,
@@ -11,8 +10,6 @@
     "limitMessages": false
   },
   "weather": {
-    "geocode_api_key": "your_key",
-    "darksky_api_key": "your_key",
     "icons": {
       "clear-day": ":sunny:",
       "clear-night": ":crescent_moon:",

--- a/start.js
+++ b/start.js
@@ -1,9 +1,13 @@
-const Settings = require('./settings.json');
 const Bot = require('./TheAwesomeBot.js');
+const Tokens = require('./tokens.json');
 
 function start() {
   // check for the discord token
-  const token = Settings.api_token || process.env.DISCORD_TOKEN;
+  let jsonToken = false;
+  if (Tokens) {
+    jsonToken = Tokens.discord;
+  }
+  const token = jsonToken || process.env.DISCORD_TOKEN;
   if (!token) {
     throw Error('Discord token not set');
   }

--- a/tokens.json.example
+++ b/tokens.json.example
@@ -1,0 +1,5 @@
+{
+    "discord": "",
+    "google_geocode": "",
+    "darksky": ""
+}


### PR DESCRIPTION
Based on a tip from @melmsie, it's probably better for us to isolate all the secrets (APIs tokens/keys) in a place safe from accidental commits.

I created a `tokens.json.example` that would have to be copied/renamed to `tokens.json` (which is git-ignored) and then filled with the appropriate keys. This way it's not necessary to mess with `settings.json` and accidentally commit the secrets in it.

Anyone against it or have ideas to improve?