### PR TITLE
Trimmed codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,13 +1,5 @@
 ---
 engines:
-  duplication:
-    enabled: true
-    config:
-      languages:
-      - ruby
-      - javascript
-      - python
-      - php
   eslint:
     enabled: true
     channel: "eslint-3"
@@ -15,14 +7,4 @@ engines:
     enabled: true
 ratings:
   paths:
-  - "**.inc"
   - "**.js"
-  - "**.jsx"
-  - "**.module"
-  - "**.php"
-  - "**.py"
-  - "**.rb"
-exclude_paths:
-- "tests/"
-- "spec/"
-- "**/vendor/"


### PR DESCRIPTION
Tested with codeclimate, it is correctly finding the problems. Codeclimate suggests applying this patch to our linter configuration for better results:
```diff
diff --git a/.eslintignore b/.eslintignore
index e69de29..96212a3 100644
--- a/.eslintignore
+++ b/.eslintignore
@@ -0,0 +1 @@
+**/*{.,-}min.js
diff --git a/.eslintrc b/.eslintrc
index e69de29..9faa375 100644
--- a/.eslintrc
+++ b/.eslintrc
@@ -0,0 +1,213 @@
+ecmaFeatures:
+  modules: true
```