### PR TITLE
Improve help links

### DIFF
--- a/commands/help/topics/cpp.txt
+++ b/commands/help/topics/cpp.txt
@@ -1,5 +1,10 @@
 See these links/courses for learning C++:
 
+Reference
+<http://en.cppreference.com/w/>
+
+The Definitive C++ Book Guide and List
 <http://stackoverflow.com/a/388282>
 
-<https://www.reddit.com/r/learnprogramming/wiki/faq_cpp>
+C++ FAQ
+<https://reddit.com/r/learnprogramming/wiki/faq_cpp>

--- a/commands/help/topics/cpp.txt
+++ b/commands/help/topics/cpp.txt
@@ -1,4 +1,5 @@
 See these links/courses for learning C++:
 
-http://stackoverflow.com/a/388282
-https://www.reddit.com/r/learnprogramming/wiki/faq_cpp
+<http://stackoverflow.com/a/388282>
+
+<https://www.reddit.com/r/learnprogramming/wiki/faq_cpp>

--- a/commands/help/topics/css.txt
+++ b/commands/help/topics/css.txt
@@ -1,7 +1,7 @@
 See these links for learning CSS:
 
-https://www.codecademy.com/learn/web
+<https://www.codecademy.com/learn/web>
 
-http://www.w3schools.com/css/default.asp
+<http://www.w3schools.com/css/default.asp>
 
-http://learnlayout.com/
+<http://learnlayout.com/>

--- a/commands/help/topics/css.txt
+++ b/commands/help/topics/css.txt
@@ -1,7 +1,13 @@
 See these links for learning CSS:
 
-<https://www.codecademy.com/learn/web>
+Tutorials/Documentation (In-depth)
+<https://developer.mozilla.org/en-US/docs/Web/CSS>
 
-<http://www.w3schools.com/css/default.asp>
+Free Course: Learn the basics of HTML and CSS
+<https://codecademy.com/learn/web>
 
+Tutorials/Documentation (Good for Quick Reference)
+<https://w3schools.com/css/default.asp>
+
+Tutorial: Simple introduction to CSS
 <http://learnlayout.com/>

--- a/commands/help/topics/dotnet.txt
+++ b/commands/help/topics/dotnet.txt
@@ -1,8 +1,7 @@
 See these links/courses for learning .NET/C#:
 
-https://msdn.microsoft.com/en-us/library/aa288436(v=vs.71).aspx
+<https://msdn.microsoft.com/en-us/library/aa288436(v=vs.71).aspx>
 
-https://msdn.microsoft.com/en-us/library/xk24xdbe(v=vs.90).aspx
+<https://msdn.microsoft.com/en-us/library/xk24xdbe(v=vs.90).aspx>
 
-https://www.youtube.com/watch?v=Yj0G5UdBJZw&list=PLEbaEyM-xt9mVQEAXGlRRmbO2Qp_oqF-n
-
+<https://www.youtube.com/watch?v=Yj0G5UdBJZw&list=PLEbaEyM-xt9mVQEAXGlRRmbO2Qp_oqF-n>

--- a/commands/help/topics/dotnet.txt
+++ b/commands/help/topics/dotnet.txt
@@ -1,7 +1,13 @@
 See these links/courses for learning .NET/C#:
 
-<https://msdn.microsoft.com/en-us/library/aa288436(v=vs.71).aspx>
+Free Course: Fundamentals for Absolute Beginners
+<https://mva.microsoft.com/en-us/training-courses/c-fundamentals-for-absolute-beginners-16169>
 
-<https://msdn.microsoft.com/en-us/library/xk24xdbe(v=vs.90).aspx>
-
+Video Series: Getting Started with Visual Studio & C# .NET with Nerdgasm
 <https://www.youtube.com/watch?v=Yj0G5UdBJZw&list=PLEbaEyM-xt9mVQEAXGlRRmbO2Qp_oqF-n>
+
+Book: C# in Depth, Third Edition by Jon Skeet (http://meta.stackexchange.com/q/9134)
+<https://www.manning.com/books/c-sharp-in-depth-third-edition>
+
+Paid Course Library: Fundamentals, ASP.NET MVC, LINQ, Entity Framework and more
+<https://teamtreehouse.com/library/topic:csharp>

--- a/commands/help/topics/java.txt
+++ b/commands/help/topics/java.txt
@@ -1,7 +1,10 @@
 See these links/courses for learning Java:
 
+Documentation for Java 7
 <https://docs.oracle.com/javase/7/docs/api/>
 
+Documentation for Java 8
 <https://docs.oracle.com/javase/8/docs/api/>
 
+Tutorials
 <https://docs.oracle.com/javase/tutorial/>

--- a/commands/help/topics/java.txt
+++ b/commands/help/topics/java.txt
@@ -1,8 +1,7 @@
 See these links/courses for learning Java:
 
-https://docs.oracle.com/javase/7/docs/api/
+<https://docs.oracle.com/javase/7/docs/api/>
 
-https://docs.oracle.com/javase/8/docs/api/
+<https://docs.oracle.com/javase/8/docs/api/>
 
-https://docs.oracle.com/javase/tutorial/
-
+<https://docs.oracle.com/javase/tutorial/>

--- a/commands/help/topics/javascript.txt
+++ b/commands/help/topics/javascript.txt
@@ -1,11 +1,28 @@
 See these links/courses for learning JavaScript:
 
-<https://www.codecademy.com/learn/javascript>
-
-<https://www.udacity.com/course/javascript-basics--ud804>
-
+Tutorials/Documentation
 <https://developer.mozilla.org/en-US/docs/Web/JavaScript>
 
-<https://www.youtube.com/watch?v=VJOTcUsD2kA>
+Free to Read Online: A Modern Introduction to Programming
+<http://eloquentjavascript.net/>
 
-<https://www.youtube.com/watch?v=8aGhZQkoFbQ>
+Free Course: Fundamental Programming Concepts
+<https://codecademy.com/learn/javascript>
+
+Free Course Library: Learn to Code and Help Nonprofits
+<https://freecodecamp.com/>
+
+Free Course: Basic JavaScript (~3 weeks)
+<https://udacity.com/course/javascript-basics--ud804>
+
+Talk: Four Layers of JavaScript OOP (1:09:02)
+<https://youtu.be/VJOTcUsD2kA>
+
+Talk: How Node.js' Event Loop Works (26:52)
+<https://youtu.be/8aGhZQkoFbQ>
+
+Paid Course Library: In-depth Fundamentals, Node, React, jQuery and more
+<https://teamtreehouse.com/library/topic:javascript>
+
+Free to Read Online Series: You Don't Know JS (Core Mechanisms, Advanced)
+<https://github.com/getify/You-Dont-Know-JS>

--- a/commands/help/topics/javascript.txt
+++ b/commands/help/topics/javascript.txt
@@ -1,11 +1,11 @@
 See these links/courses for learning JavaScript:
 
-https://www.codecademy.com/learn/javascript
+<https://www.codecademy.com/learn/javascript>
 
-https://www.udacity.com/course/javascript-basics--ud804
+<https://www.udacity.com/course/javascript-basics--ud804>
 
-https://developer.mozilla.org/en-US/docs/Web/JavaScript
+<https://developer.mozilla.org/en-US/docs/Web/JavaScript>
 
-https://www.youtube.com/watch?v=VJOTcUsD2kA
+<https://www.youtube.com/watch?v=VJOTcUsD2kA>
 
-https://www.youtube.com/watch?v=8aGhZQkoFbQ
+<https://www.youtube.com/watch?v=8aGhZQkoFbQ>

--- a/commands/help/topics/php.txt
+++ b/commands/help/topics/php.txt
@@ -1,8 +1,7 @@
 See these links/courses for learning PHP:
 
-http://www.w3schools.com/php/
+<http://www.w3schools.com/php/>
 
-http://php.net/manual/en/tutorial.php
+<http://php.net/manual/en/tutorial.php>
 
-https://www.codecademy.com/learn/php
-
+<https://www.codecademy.com/learn/php>

--- a/commands/help/topics/php.txt
+++ b/commands/help/topics/php.txt
@@ -1,7 +1,10 @@
 See these links/courses for learning PHP:
 
-<http://www.w3schools.com/php/>
+PHP 5 Tutorials
+<https://w3schools.com/php/>
 
-<http://php.net/manual/en/tutorial.php>
+A simple tutorial
+<https://php.net/manual/en/tutorial.php>
 
-<https://www.codecademy.com/learn/php>
+Free Course: Fundamental Programming Concepts
+<https://codecademy.com/learn/php>

--- a/commands/help/topics/python.txt
+++ b/commands/help/topics/python.txt
@@ -1,11 +1,19 @@
 See these links/courses for learning Python:
 
+Documentation
 <https://docs.python.org/3/>
 
-<https://www.udacity.com/course/programming-foundations-with-python--ud036>
+Free to Read Online: Introduction to Programming for Beginners
+<https://greenteapress.com/wp/think-python-2e/>
 
+Free to Read Online: Language Basics and Task Automation
 <https://automatetheboringstuff.com/>
 
-<https://www.udacity.com/course/intro-to-computer-science--cs101>
+Paid Course Library: In-depth Fundamentals, Flask, Django and more
+<https://teamtreehouse.com/library/topic:python>
 
-<http://greenteapress.com/wp/think-python-2e/>
+Free Course: Programming Fundamentals and OOP (~6 weeks)
+<https://udacity.com/course/programming-foundations-with-python--ud036>
+
+Free Course: Build a Search Engine and a Social Network (~3 months)
+<https://udacity.com/course/intro-to-computer-science--cs101>

--- a/commands/help/topics/python.txt
+++ b/commands/help/topics/python.txt
@@ -1,11 +1,11 @@
 See these links/courses for learning Python:
 
-https://docs.python.org/3/
+<https://docs.python.org/3/>
 
-https://www.udacity.com/course/programming-foundations-with-python--ud036
+<https://www.udacity.com/course/programming-foundations-with-python--ud036>
 
-https://automatetheboringstuff.com/
+<https://automatetheboringstuff.com/>
 
-https://www.udacity.com/course/intro-to-computer-science--cs101
+<https://www.udacity.com/course/intro-to-computer-science--cs101>
 
-http://greenteapress.com/wp/think-python-2e/
+<http://greenteapress.com/wp/think-python-2e/>

--- a/commands/help/topics/react.txt
+++ b/commands/help/topics/react.txt
@@ -1,9 +1,9 @@
 See these links for learning ReactJS/Flux/Redux:
 
-https://facebook.github.io/react/docs/getting-started.html
+<https://facebook.github.io/react/docs/getting-started.html>
 
-https://www.youtube.com/watch?v=MhkGQAoc7bc&list=PLoYCgNOIyGABj2GQSlDRjgvXtqfDxKm5b
+<https://www.youtube.com/watch?v=MhkGQAoc7bc&list=PLoYCgNOIyGABj2GQSlDRjgvXtqfDxKm5b>
 
-https://www.codecademy.com/learn/react-101
+<https://www.codecademy.com/learn/react-101>
 
-https://www.codecademy.com/learn/react-102
+<https://www.codecademy.com/learn/react-102>

--- a/commands/help/topics/react.txt
+++ b/commands/help/topics/react.txt
@@ -1,9 +1,13 @@
 See these links for learning ReactJS/Flux/Redux:
 
-<https://facebook.github.io/react/docs/getting-started.html>
+Hello World in React
+<https://facebook.github.io/react/docs/hello-world.html>
 
+Free Course: Get Quickly in Pace with React.js Development
 <https://www.youtube.com/watch?v=MhkGQAoc7bc&list=PLoYCgNOIyGABj2GQSlDRjgvXtqfDxKm5b>
 
+Free Course: Essential Concepts
 <https://www.codecademy.com/learn/react-101>
 
+Free Course: Continuation: Lifecycle Methods, Stateless Components and more
 <https://www.codecademy.com/learn/react-102>

--- a/commands/help/topics/style.txt
+++ b/commands/help/topics/style.txt
@@ -1,3 +1,3 @@
 Here is a link to Discord's text styles:
 
-<https://support.discordapp.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline->
+https://support.discordapp.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-

--- a/commands/help/topics/style.txt
+++ b/commands/help/topics/style.txt
@@ -1,4 +1,3 @@
 Here is a link to Discord's text styles:
 
-https://support.discordapp.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-
-
+<https://support.discordapp.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline->


### PR DESCRIPTION
These series of commits introduce a lot of changes to help links like:

- Removing embeds
- Adding text descriptions to each
- Adding treehouse links where it is possible
- Adding more book and reference links to C#, C++ and JS
- Convert HTTP to HTTPS when the website supports it (a lot of them don't, surprisingly)
- Shorten links where it is possible
- Fix broken/redirected links