### PR TITLE
Shortening nohello message

### DIFF
--- a/commands/quickref/references/nohello.txt
+++ b/commands/quickref/references/nohello.txt
@@ -1,16 +1,16 @@
 __**Please Don't Say Just Hello In Chat**__
 ```
-2010-07-19 12:32:12 you: Hi
-2010-07-19 12:32:15 co-worker: Hello.
+2016-07-19 12:32:12 you: Hi
+2016-07-19 12:32:15 co-worker: Hello.
 ## CO-WORKER WAITS WHILE YOU PHRASE YOUR QUESTION
-2010-07-19 12:34:01 you: I'm working on [something] and I'm trying to do [etc...]
-2010-07-19 12:35:21 co-worker: Oh, that's [answer...]
+2016-07-19 12:34:01 you: I'm working on [something] and I'm trying to do [etc...]
+2016-07-19 12:35:21 co-worker: Oh, that's [answer...]
 ```
 It's as if you called someone on the phone and said "Hi!" and then put them on hold!
 
 Please do this instead:
 ```
-2010-07-19 12:32:12 you: Hi -- I'm working on [something] and I'm trying to do [etc...]
-2010-07-19 12:33:32 co-worker: [answers question]
+2016-07-19 12:32:12 you: Hi -- I'm working on [something] and I'm trying to do [etc...]
+2016-07-19 12:33:32 co-worker: [answers question]
 ```
-*Please continue your education at http://nohello.com/*
+*You can learn more at http://nohello.com/*

--- a/commands/quickref/references/nohello.txt
+++ b/commands/quickref/references/nohello.txt
@@ -13,8 +13,4 @@ Please do this instead:
 2010-07-19 12:32:12 you: Hi -- I'm working on [something] and I'm trying to do [etc...]
 2010-07-19 12:33:32 co-worker: [answers question]
 ```
-If you feel it's brusque to simply say "Hi" and ask the question, you can do something like this:
-```
-2010-07-19 12:32:12 you: Hi -- if you're not busy I was wondering if I could ask a question.  I'm working on [something] and I'm trying to do [etc...]
-```
 *Please continue your education at http://nohello.com/*


### PR DESCRIPTION
It's too long. It takes up a full screen on mobile. This last paragraph is nonessential to the point that we want questions asked, not greetings, so removing it is fine. Besides, there's a link to the source if they want to read more.