### PR TITLE
Fixed eval block parsing

### DIFF
--- a/commands/eval/eval.js
+++ b/commands/eval/eval.js
@@ -88,7 +88,7 @@ module.exports = {
     const rx = new RegExp('^(`{0,3})(' + rxLangs + ')\\s*((.|\\s)+)(\\1)$', 'gi');
     const argsArr = rx.exec(cmdArgs);
     let lang = argsArr[2].toLowerCase();
-    const code = (new RegExp('^(`{0,3})((' + rxLangs + '|.{0})\\s)?\\s*((.|\\s)+)(\\1)$', 'gi')).exec(argsArr[3])[3];
+    const code = (new RegExp('^(`{0,3})((' + rxLangs + '|.{0})\\s)?\\s*((.|\\s)+)(\\1)$', 'gi')).exec(argsArr[3])[4];
     lang = validateLang(lang);
     if (!lang) {
       message.reply('Sorry, I don\'t know that language!');

--- a/commands/eval/eval.js
+++ b/commands/eval/eval.js
@@ -85,10 +85,10 @@ module.exports = {
                         });
     rxLangs.push(...availableLanguages);
     rxLangs = rxLangs.sort((a, b) => b.length - a.length).join('|');
-    const rx = new RegExp('^(`{0,3})(' + rxLangs + ')\\s{0,}((.|\\s){1,})(\\1)$', 'gi');
+    const rx = new RegExp('^(`{0,3})(' + rxLangs + ')\\s*((.|\\s)+)(\\1)$', 'gi');
     const argsArr = rx.exec(cmdArgs);
     let lang = argsArr[2].toLowerCase();
-    const code = (new RegExp('^(`{0,3})(' + rxLangs + '|.{0})\\s{0,}((.|\\s){1,})(\\1)$', 'gi')).exec(argsArr[3])[3];
+    const code = (new RegExp('^(`{0,3})((' + rxLangs + '|.{0})\\s)?\\s*((.|\\s)+)(\\1)$', 'gi')).exec(argsArr[3])[3];
     lang = validateLang(lang);
     if (!lang) {
       message.reply('Sorry, I don\'t know that language!');


### PR DESCRIPTION
Fixed eval block parsing, so that if the code starts with a pattern that matches lang identity, isn't parsed as lang identity.

Example:
   !bot eval js console.log(7);
   \\ earlier c would be parsed as an lang identity and onsole.log(7) would be marked as code, now it would behave as expected, needs to be tested with the bot